### PR TITLE
add no comment variable to surpress comment creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ evaluators: []
 
 An assessment value will be attempted to be extracted from the AI responses by trying to find a line matching `/^###.*Assessment:/` (i.e. `### AI Assessment` or `### Alignment Assessment`). If no value is found, then the value `unsure` will be used. The assessment is then downcased and prefixed with `ai:` and the `.prompt.yml` file name and added as a label to the issue (i.e. `ai:intake-prompt:aligned`, `ai:intake-prompt:neutral`, `ai:intake-prompt:not aligned`, `ai:intake-prompt:ready for review`, `ai:bug-prompt:missing details`, `ai:bug-prompt:unsure`). The assessment values largely depend on the instructions in the system prompt section. Finally this action will remove the `ai_review_label` trigger label. If you want a new review you can edit your issue body and then re-add the `ai_review_label` trigger label.
 
+If you want to just have the ai assessment label added to the issue and surpress the creation of the comment, then you can use the `no_comment_regex_pattern` variable. The way this works is you update your system prompt to add a "no comment" identifier in the response e.g. "If the assessment is in the affirmative then add `<!-- no-comment -->` to the response body."  You can then set `no_comment_regex_pattern: '<!--.*no.*comment.*-->'` and `no_comment_regex_flags: gmi`. If the regex is found in the response the the comment creation step is skipped and the issue will still be labeled with the identified assessment. The ai assessment will still be added the action output summary so it can be viewed.
+
 ### Inputs
 
 Various inputs are defined in [action.yml](action.yml) to let you configure
@@ -69,6 +71,8 @@ the action:
 | `owner` | The name of the repository owner | false | |
 | `assessment_regex_pattern` | Regex pattern for capturing the assessment line in the AI response used for creating the label to add to the issue. | false | "^###.*[aA]ssessment:\s*(.+)$" |
 | `assessment_regex_flags` | Regex flags for the assessment regex pattern. e.g.: "i" for case-insensitive matching. | false | "" |
+| `no_comment_regex_pattern` | Regex pattern for capturing the no comment directive in the AI response. e.g.: "<!--.*no.*comment.*-->" | false | "" |
+| `no_comment_regex_flags` | Regex flags for the no comment regex pattern. e.g.: "i" for case-insensitive matching. | false | "" |
 
 ### Example Workflow Setup
 Below is an example workflow action file you can setup for this action. This setup would trigger everytime an issue had a label assigned to it. You can configure your issue templates to assign default labels on creation that then map to specific `.prompt.yml` files you have saved in your repository. So when users open a `bug` issue that is created with the labels `bug` and `request ai review`. In the example below  `ai_review_label` is set to `request ai review`, which means every time `request ai review` label is added to an issue this action will run. Since we are mapping `bug` to `bug-review.prompt.yml` in the `labels_to_prompts_mapping` field, this action will use the `bug-review.prompt.yml` file to pull the `system prompt` to use and the `model` and `max_tokens` options. If you want to override the `model` and `max_token` options that are in your `.prompt.yml` file you can pass those into the workflow action below as `model` and `max_tokens` variables.

--- a/action.yml
+++ b/action.yml
@@ -47,6 +47,14 @@ inputs:
     description: 'Regex flags for the assessment regex pattern. e.g.: "i" for case-insensitive matching.'
     required: false
     default: ''
+  no_comment_regex_pattern:
+    description: 'Regex pattern for capturing the no comment directive in the AI response. e.g.: "<!--.*no.*comment.*-->"'
+    required: false
+    default: ''
+  no_comment_regex_flags:
+    description: 'Regex flags for the no comment regex pattern. e.g.: "i" for case-insensitive matching.'
+    required: false
+    default: ''
 runs:
   using: node20
   main: dist/index.js

--- a/src/__tests__/utils.test.ts
+++ b/src/__tests__/utils.test.ts
@@ -125,48 +125,50 @@ describe("getPromptFilesFromLabels", () => {
   });
 });
 
-  describe("getRegexFromString", () => {
-    it("should create a valid regex with pattern and flags", () => {
-      const regex = getRegexFromString("test", "gi");
-      expect(regex).toBeInstanceOf(RegExp);
-      expect(regex.source).toBe("test");
-      expect(regex.flags).toBe("gi");
-    });
-
-    it("should create a regex with no flags", () => {
-      const regex = getRegexFromString("hello", "");
-      expect(regex).toBeInstanceOf(RegExp);
-      expect(regex.source).toBe("hello");
-      expect(regex.flags).toBe("");
-    });
-
-    it("should create a case-insensitive regex", () => {
-      const regex = getRegexFromString("Assessment", "i");
-      expect(regex.test("assessment")).toBe(true);
-      expect(regex.test("ASSESSMENT")).toBe(true);
-    });
-
-    it("should throw error for invalid regex pattern", () => {
-      expect(() => {
-        getRegexFromString("[invalid", "");
-      }).toThrow(/Invalid regex pattern or flags provided/);
-    });
-
-    it("should throw error for invalid regex flags", () => {
-      expect(() => {
-        getRegexFromString("valid", "x");
-      }).toThrow(/Invalid regex pattern or flags provided/);
-    });
-
-    it("should handle complex regex patterns", () => {
-      const regex = getRegexFromString("^###.*[aA]ssessment:\\s*(.+)$", "");
-      expect(regex).toBeInstanceOf(RegExp);
-      expect(regex.test("### Alignment Assessment: Aligned")).toBe(true);
-    });
-
-    it("should handle hidden text regex patterns", () => {
-      const regex = getRegexFromString("<!--.*no.*comment.*-->", "gmi");
-      expect(regex).toBeInstanceOf(RegExp);
-      expect(regex.test("### Well-form: Yes\n<!-- NO-COMMENT -->\nThis is a test.")).toBe(true);
-    });
+describe("getRegexFromString", () => {
+  it("should create a valid regex with pattern and flags", () => {
+    const regex = getRegexFromString("test", "gi");
+    expect(regex).toBeInstanceOf(RegExp);
+    expect(regex.source).toBe("test");
+    expect(regex.flags).toBe("gi");
   });
+
+  it("should create a regex with no flags", () => {
+    const regex = getRegexFromString("hello", "");
+    expect(regex).toBeInstanceOf(RegExp);
+    expect(regex.source).toBe("hello");
+    expect(regex.flags).toBe("");
+  });
+
+  it("should create a case-insensitive regex", () => {
+    const regex = getRegexFromString("Assessment", "i");
+    expect(regex.test("assessment")).toBe(true);
+    expect(regex.test("ASSESSMENT")).toBe(true);
+  });
+
+  it("should throw error for invalid regex pattern", () => {
+    expect(() => {
+      getRegexFromString("[invalid", "");
+    }).toThrow(/Invalid regex pattern or flags provided/);
+  });
+
+  it("should throw error for invalid regex flags", () => {
+    expect(() => {
+      getRegexFromString("valid", "x");
+    }).toThrow(/Invalid regex pattern or flags provided/);
+  });
+
+  it("should handle complex regex patterns", () => {
+    const regex = getRegexFromString("^###.*[aA]ssessment:\\s*(.+)$", "");
+    expect(regex).toBeInstanceOf(RegExp);
+    expect(regex.test("### Alignment Assessment: Aligned")).toBe(true);
+  });
+
+  it("should handle hidden text regex patterns", () => {
+    const regex = getRegexFromString("<!--.*no.*comment.*-->", "gmi");
+    expect(regex).toBeInstanceOf(RegExp);
+    expect(
+      regex.test("### Well-form: Yes\n<!-- NO-COMMENT -->\nThis is a test."),
+    ).toBe(true);
+  });
+});

--- a/src/__tests__/utils.test.ts
+++ b/src/__tests__/utils.test.ts
@@ -3,6 +3,7 @@ import {
   getPromptOptions,
   getAILabelAssessmentValue,
   getPromptFilesFromLabels,
+  getRegexFromString,
 } from "../utils";
 
 describe("getPromptOptions", () => {
@@ -122,23 +123,50 @@ describe("getPromptFilesFromLabels", () => {
       }),
     ).toEqual(["bug-review.prompt.yml"]);
   });
-
-  it("should return both files for the labels matched to the mapping", () => {
-    const issueLabels = [
-      { name: "request ai review" },
-      { name: "bug" },
-      { name: "support request" },
-    ];
-    const labelsToPromptsMapping =
-      "support request,request-intake.prompt.yml|bug,bug-review.prompt.yml";
-
-    const labels = getPromptFilesFromLabels({
-      issueLabels,
-      labelsToPromptsMapping,
-    });
-    expect(
-      labels.includes("request-intake.prompt.yml") &&
-        labels.includes("bug-review.prompt.yml"),
-    ).toEqual(true);
-  });
 });
+
+  describe("getRegexFromString", () => {
+    it("should create a valid regex with pattern and flags", () => {
+      const regex = getRegexFromString("test", "gi");
+      expect(regex).toBeInstanceOf(RegExp);
+      expect(regex.source).toBe("test");
+      expect(regex.flags).toBe("gi");
+    });
+
+    it("should create a regex with no flags", () => {
+      const regex = getRegexFromString("hello", "");
+      expect(regex).toBeInstanceOf(RegExp);
+      expect(regex.source).toBe("hello");
+      expect(regex.flags).toBe("");
+    });
+
+    it("should create a case-insensitive regex", () => {
+      const regex = getRegexFromString("Assessment", "i");
+      expect(regex.test("assessment")).toBe(true);
+      expect(regex.test("ASSESSMENT")).toBe(true);
+    });
+
+    it("should throw error for invalid regex pattern", () => {
+      expect(() => {
+        getRegexFromString("[invalid", "");
+      }).toThrow(/Invalid regex pattern or flags provided/);
+    });
+
+    it("should throw error for invalid regex flags", () => {
+      expect(() => {
+        getRegexFromString("valid", "x");
+      }).toThrow(/Invalid regex pattern or flags provided/);
+    });
+
+    it("should handle complex regex patterns", () => {
+      const regex = getRegexFromString("^###.*[aA]ssessment:\\s*(.+)$", "");
+      expect(regex).toBeInstanceOf(RegExp);
+      expect(regex.test("### Alignment Assessment: Aligned")).toBe(true);
+    });
+
+    it("should handle hidden text regex patterns", () => {
+      const regex = getRegexFromString("<!--.*no.*comment.*-->", "gmi");
+      expect(regex).toBeInstanceOf(RegExp);
+      expect(regex.test("### Well-form: Yes\n<!-- NO-COMMENT -->\nThis is a test.")).toBe(true);
+    });
+  });

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,8 +37,13 @@ const main = async () => {
   const noCommentRegexPattern = getInput("no_comment_regex_pattern");
   const noCommentRegexFlags = getInput("no_comment_regex_flags");
 
-  const aiAssessmentRegex = getRegexFromString(assessmentRegexPattern, assessmentRegexFlags);
-  const noCommentRegex = noCommentRegexPattern ? getRegexFromString(noCommentRegexPattern, noCommentRegexFlags) : null;
+  const aiAssessmentRegex = getRegexFromString(
+    assessmentRegexPattern,
+    assessmentRegexFlags,
+  );
+  const noCommentRegex = noCommentRegexPattern
+    ? getRegexFromString(noCommentRegexPattern, noCommentRegexFlags)
+    : null;
 
   if (
     !token ||

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -28,7 +28,10 @@ const MAX_TOKENS = 200;
 const AI_MODEL = "openai/gpt-4o-mini";
 const ENDPOINT = "https://models.github.ai/inference";
 
-export const getRegexFromString = (regexString: string, regexFlags: string): RegExp => {
+export const getRegexFromString = (
+  regexString: string,
+  regexFlags: string,
+): RegExp => {
   let regex;
   try {
     regex = new RegExp(regexString, regexFlags);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -28,6 +28,19 @@ const MAX_TOKENS = 200;
 const AI_MODEL = "openai/gpt-4o-mini";
 const ENDPOINT = "https://models.github.ai/inference";
 
+export const getRegexFromString = (regexString: string, regexFlags: string): RegExp => {
+  let regex;
+  try {
+    regex = new RegExp(regexString, regexFlags);
+    console.log("Debug: Constructed regex:", regex);
+  } catch (error) {
+    throw new Error(
+      `Invalid regex pattern or flags provided: pattern="${regexString}", flags="${regexFlags}". Error: ${error}`,
+    );
+  }
+  return regex;
+};
+
 export const writeActionSummary = ({
   promptFile,
   aiResponse,


### PR DESCRIPTION
### Description
Added a new no_comment_regex variable that allows users to instruct their prompts to add a hidden `<!-- no-comment -->` blurb to the response in order to suppress the creation of the AI response as an issue comment. This will cause the action to skip creating the issue comment and instead just add the ai assessment label. The comment is still added to the action summary for viewing. 


### Testing
- Setup a `.prompt.yml` file with the following added to the system prompt:
```
If the assessment is in the affirmative then add "<!-- NO-COMMENT -->" to the body of the response.
```

- update action env's to include:
```
  no_comment_regex_pattern: '<!--.*no.*comment.*-->'
  no_comment_regex_flags: 'gmi'
  ```